### PR TITLE
feat: rds 연결 설정 및 security 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,14 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    implementation 'com.mysql:mysql-connector-j'
+
     compileOnly 'org.projectlombok:lombok'
 
-    runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'com.mysql:mysql-connector-j'
+
     runtimeOnly 'com.h2database:h2'
 
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/matal/MatalApplication.java
+++ b/src/main/java/matal/MatalApplication.java
@@ -2,8 +2,9 @@ package matal;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class MatalApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/matal/config/SecurityConfig.java
+++ b/src/main/java/matal/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package matal.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    public SecurityConfig(){
+
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        return httpSecurity
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .headers(httpSecurityHeadersConfigurer -> httpSecurityHeadersConfigurer
+                        .frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+                .sessionManagement((sessionManagement) -> sessionManagement
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/swagger-ui/**", "/swagger-ui").permitAll()
+                        .anyRequest().permitAll())
+                .build();
+    }
+}

--- a/src/test/java/matal/MatalApplicationTests.java
+++ b/src/test/java/matal/MatalApplicationTests.java
@@ -3,7 +3,7 @@ package matal;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = MatalApplicationTests.class)
 class MatalApplicationTests {
 
     @Test


### PR DESCRIPTION
### 개요

- RDS Database 설정 및 security 설정 필요에 의한 구현

### 반영 브랜치

- `feature/security-rds-setup` -> `main`

### PR 타입

- 기능 추가

### 변경 사항

- MySQL RDS 연결 설정
- SecurityConfig 구현

### 테스트 결과

- [x] 정상 빌드 확인