### PR TITLE
refactor: 배포 파일 경로 수정

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -2,13 +2,13 @@ version: 0.0
 os: linux
 files:
   - source: build/libs/matal-server-0.0.1-SNAPSHOT.jar
-    destination: /home/ubuntu/app/zip/
+    destination: /home/ubuntu/backend
     overwrite: yes
   - source: appspec.yml
-    destination: /home/ubuntu/app/zip/
+    destination: /home/ubuntu/backend/
     overwrite: yes
   - source: scripts
-    destination: /home/ubuntu/app/zip/
+    destination: /home/ubuntu/backend/
     overwrite: yes
 
 permissions:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-REPOSITORY=/home/ubuntu/app/zip
+REPOSITORY=/home/ubuntu/backend
 
 echo "> 현재 구동 중인 애플리케이션 pid 확인"
 


### PR DESCRIPTION
### 개요

- ec2 내에 백엔드, 프론트엔드 서버 배포 분리를 위한 경로 수정

### 반영 브랜치

- `refactor/ci-cd` -> `main`

### PR 타입

- 리팩터링

### 변경 사항

- 백엔드 배포 경로를 `/home/ubuntu/backend` 로 수정

### 테스트 결과

- [X] 배포 경로 수정 확인