### PR TITLE
feat: WebConfig 추가로 CORS 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,7 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok'
 
-    implementation 'com.mysql:mysql-connector-j'
-
+    runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'
 
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/matal/config/WebConfig.java
+++ b/src/main/java/matal/config/WebConfig.java
@@ -1,0 +1,39 @@
+package matal.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${spring.cors.allowed-origins}")
+    private String ALLOWED_ORIGINS;
+
+    @Value("${spring.cors.allowed-methods}")
+    private String ALLOWED_METHODS;
+
+    @Value("${spring.cors.allowed-headers-1}")
+    private String ALLOWED_HEADERS_KEY_1;
+
+    @Value("${spring.cors.allowed-headers-2}")
+    private String ALLOWED_HEADERS_KEY_2;
+
+    @Value("${spring.cors.exposed-headers}")
+    private String EXPOSED_HEADERS;
+
+    @Value("${spring.cors.allow-credentials}")
+    private boolean ALLOW_CREDENTIALS;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(ALLOWED_ORIGINS.split(","))
+                .allowedMethods(ALLOWED_METHODS.split(","))
+                .allowedHeaders(ALLOWED_HEADERS_KEY_1, ALLOWED_HEADERS_KEY_2)
+                .exposedHeaders(EXPOSED_HEADERS)
+                .allowCredentials(ALLOW_CREDENTIALS)
+                .maxAge(3600);
+    }
+}


### PR DESCRIPTION
### 개요

- CORS 설정을 통해 통신 허용

### 반영 브랜치

- `feature/web-config` -> `main`

### PR 타입

- 기능 추가

### 변경 사항

- WebConfig 를 통해 Ec2 서버와 로컬 서버 추가

### 테스트 결과

- [X] CORS 에러 없이 접속 허용