### PR TITLE
feat: 상세 정보 조회 기능과 정렬 기능 개발

### DIFF
--- a/src/main/java/matal/store/controller/StoreController.java
+++ b/src/main/java/matal/store/controller/StoreController.java
@@ -8,14 +8,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import matal.store.dto.StoreRequestDto;
+import matal.store.dto.StoreInfoResponseDto;
 import matal.store.dto.StoreResponseDto;
 import matal.store.service.StoreService;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/stores")
@@ -70,17 +68,17 @@ public class StoreController {
         return storeService.findStoresByStation(nearby_station);
     }
 
-//    //가게 상세 정보 조회
-//    @GetMapping("{storeid}")
-//    @Operation(summary = "Get store detail infotmation", description = "가게 리스트 중 하나를 클릭하면 해당 가게의 상세 정보, 리뷰 등을 조회할 수 있다.")
-//    @ApiResponses(value = {
-//            @ApiResponse(responseCode = "200", description = "성공",
-//            content = {@Content(schema = @Schema(implementation = StoreResponseDto.class))}),
-//            @ApiResponse(responseCode = "404", description = "실패"),
-//    })
-//    public Optional<Store> getstoreDetail(
-//            @PathVariable Long storeid
-//    ) {
-//        return storeRepository.findById(storeid);
-//    }
+    //가게 상세 정보 조회
+    @GetMapping("{storeid}")
+    @Operation(summary = "Get store detail infotmation", description = "가게 리스트 중 하나를 클릭하면 가게 번호를 조회하여 해당 가게의 상세 정보, 리뷰 등을 조회할 수 있다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공",
+            content = {@Content(schema = @Schema(implementation = StoreInfoResponseDto.class))}),
+            @ApiResponse(responseCode = "404", description = "실패"),
+    })
+    public StoreInfoResponseDto getstoreInfo(@PathVariable("storeid") Long storeid) {
+        if(storeid == null)
+            throw new IllegalArgumentException("Error");
+        return storeService.getStoreInfo(storeid);
+    }
 }

--- a/src/main/java/matal/store/controller/StoreController.java
+++ b/src/main/java/matal/store/controller/StoreController.java
@@ -23,7 +23,7 @@ public class StoreController {
 
     private final StoreService storeService;
 
-    //이름으로 가게 리스트 조회
+    //이름으로 가게 리스트 조회 + 정렬 기능
     @GetMapping("/search/name")
     @Operation(summary = "Search store List Bu name", description = "검색 결과로 나온 가게 리스트들을 확인할 수 있다.")
     @ApiResponses(value = {
@@ -32,13 +32,18 @@ public class StoreController {
                         array = @ArraySchema(schema = @Schema(implementation = StoreResponseDto.class)))}),
             @ApiResponse(responseCode = "404", description = "실패"),
     })
-    public List<StoreResponseDto> getStoreListByNmae(@RequestParam(name = "name", required = false) String name) {
+    public List<StoreResponseDto> getStoreListByNmae(
+            @RequestParam(name = "name", required = false) String name,
+            @RequestParam(value = "sortBy", required = false, defaultValue = "rating") String sortBy,
+            @RequestParam(value = "sortOrder", required = false, defaultValue = "upper") String sortOrder
+    ) {
         if(name == null)
             throw new IllegalArgumentException("Error");
-        return storeService.findStoresByName(name);
+        List<StoreResponseDto> results = storeService.findStoresByName(name);
+        return storeService.sortStores(results, sortBy, sortOrder);
     }
 
-    //카테고리로 가게 리스트 조회
+    //카테고리로 가게 리스트 조회 + 정렬 기능
     @GetMapping("/search/category")
     @Operation(summary = "Search store List Bu name", description = "검색 결과로 나온 가게 리스트들을 확인할 수 있다.")
     @ApiResponses(value = {
@@ -47,13 +52,18 @@ public class StoreController {
                             array = @ArraySchema(schema = @Schema(implementation = StoreResponseDto.class)))}),
             @ApiResponse(responseCode = "404", description = "실패"),
     })
-    public List<StoreResponseDto> getStoreListByCategory(@RequestParam(name = "category", required = false) String category) {
+    public List<StoreResponseDto> getStoreListByCategory(
+            @RequestParam(name = "category", required = false) String category,
+            @RequestParam(value = "sortBy", required = false, defaultValue = "rating") String sortBy,
+            @RequestParam(value = "sortOrder", required = false, defaultValue = "upper") String sortOrder
+    ) {
         if(category == null)
             throw new IllegalArgumentException("Error");
-        return storeService.findStoresByCategory(category);
+        List<StoreResponseDto> results = storeService.findStoresByCategory(category);
+        return storeService.sortStores(results, sortBy, sortOrder);
     }
 
-    //지하철역으로 가게 리스트 조회
+    //지하철역으로 가게 리스트 조회 + 정렬 기능
     @GetMapping("/search/nearby_station")
     @Operation(summary = "Search store List Bu name", description = "검색 결과로 나온 가게 리스트들을 확인할 수 있다.")
     @ApiResponses(value = {
@@ -62,10 +72,15 @@ public class StoreController {
                             array = @ArraySchema(schema = @Schema(implementation = StoreResponseDto.class)))}),
             @ApiResponse(responseCode = "404", description = "실패"),
     })
-    public List<StoreResponseDto> getStoreListByStation( @RequestParam(name = "nearby_station", required = false) String nearby_station) {
+    public List<StoreResponseDto> getStoreListByStation(
+            @RequestParam(name = "nearby_station", required = false) String nearby_station,
+            @RequestParam(value = "sortBy", required = false, defaultValue = "rating") String sortBy,
+            @RequestParam(value = "sortOrder", required = false, defaultValue = "upper") String sortOrder
+    ) {
         if(nearby_station == null)
             throw new IllegalArgumentException("Error");
-        return storeService.findStoresByStation(nearby_station);
+        List<StoreResponseDto> results = storeService.findStoresByStation(nearby_station);
+        return storeService.sortStores(results, sortBy, sortOrder);
     }
 
     //가게 상세 정보 조회

--- a/src/main/java/matal/store/dto/StoreInfoResponseDto.java
+++ b/src/main/java/matal/store/dto/StoreInfoResponseDto.java
@@ -1,0 +1,30 @@
+package matal.store.dto;
+
+import matal.store.entity.Store;
+
+public record StoreInfoResponseDto(
+        Long id, String name, String category, Long reviews_count, String address,
+        String nearby_station, String phone, String business_hours, Double latitude,
+        Double longitude, String positive_keywords, String review_summary, Double rating,
+        Double positive_ratio, Double negative_ratio) {
+
+    public static StoreInfoResponseDto fromInfo(Store store) {
+        return new StoreInfoResponseDto(
+                store.getId(),
+                store.getName(),
+                store.getCategory(),
+                store.getReviews_count(),
+                store.getAddress(),
+                store.getNearby_station(),
+                store.getPhone(),
+                store.getBusiness_hours(),
+                store.getLatitude(),
+                store.getLongitude(),
+                store.getPositive_keywords(),
+                store.getReview_summary(),
+                store.getRating(),
+                store.getPositive_ratio(),
+                store.getNegative_ratio()
+        );
+    }
+}

--- a/src/main/java/matal/store/dto/StoreResponseDto.java
+++ b/src/main/java/matal/store/dto/StoreResponseDto.java
@@ -3,7 +3,7 @@ package matal.store.dto;
 import matal.store.entity.Store;
 
 public record StoreResponseDto(Long id, String name, String category, Long reviews_count, String address,
-                               String nearby_station, String phone, String business_hours, Double rating){
+                               String nearby_station, String phone, String business_hours, Double rating, Double positive_ratio){
 
     public static StoreResponseDto from(Store store) {
         return new StoreResponseDto(
@@ -15,7 +15,8 @@ public record StoreResponseDto(Long id, String name, String category, Long revie
                 store.getNearby_station(),
                 store.getPhone(),
                 store.getBusiness_hours(),
-                store.getRating()
+                store.getRating(),
+                store.getPositive_ratio()
         );
     }
 }

--- a/src/main/java/matal/store/service/StoreService.java
+++ b/src/main/java/matal/store/service/StoreService.java
@@ -2,11 +2,14 @@ package matal.store.service;
 
 import lombok.RequiredArgsConstructor;
 import matal.store.dto.StoreInfoResponseDto;
+import matal.store.dto.StoreRequestDto;
 import matal.store.dto.StoreResponseDto;
 import matal.store.repository.StoreRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -40,5 +43,26 @@ public class StoreService {
     public StoreInfoResponseDto getStoreInfo(Long id) {
         return storeRepository.findById(id).map(StoreInfoResponseDto::fromInfo)
                 .orElseThrow(() -> new IllegalArgumentException("Error"));
+    }
+
+    public List<StoreResponseDto> sortStores(List<StoreResponseDto> storeResponseDtoList, String sortBy, String sortOrder) {
+
+        Comparator <StoreResponseDto> storeResponseDtoComparator = switch (sortBy) {
+            case "positive_ratio" -> Comparator.comparing(StoreResponseDto::positive_ratio);
+            case "rating" -> Comparator.comparing(StoreResponseDto::rating);
+            case "reviews_count" -> Comparator.comparing(StoreResponseDto::reviews_count);
+            default -> throw new IllegalStateException("Unexpected value: " + sortBy);
+        };
+
+        if (sortOrder.equalsIgnoreCase("upper")) { //오름차순
+            storeResponseDtoComparator = storeResponseDtoComparator;
+        } else if (sortOrder.equalsIgnoreCase("lower")) { //내림차순
+            storeResponseDtoComparator = storeResponseDtoComparator.reversed();
+        } else {
+            throw new IllegalArgumentException("Invalid sort order: " + sortOrder);
+        }
+
+        storeResponseDtoList.sort(storeResponseDtoComparator);
+        return storeResponseDtoList;
     }
 }

--- a/src/main/java/matal/store/service/StoreService.java
+++ b/src/main/java/matal/store/service/StoreService.java
@@ -1,15 +1,13 @@
 package matal.store.service;
 
 import lombok.RequiredArgsConstructor;
-import matal.store.dto.StoreRequestDto;
+import matal.store.dto.StoreInfoResponseDto;
 import matal.store.dto.StoreResponseDto;
-import matal.store.entity.Store;
 import matal.store.repository.StoreRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @Transactional
@@ -37,5 +35,10 @@ public class StoreService {
                 .orElseThrow(() -> new IllegalArgumentException("Error"))
                 .stream().map(StoreResponseDto::from)
                 .toList();
+    }
+
+    public StoreInfoResponseDto getStoreInfo(Long id) {
+        return storeRepository.findById(id).map(StoreInfoResponseDto::fromInfo)
+                .orElseThrow(() -> new IllegalArgumentException("Error"));
     }
 }

--- a/src/test/java/matal/store/service/StoreServiceTest.java
+++ b/src/test/java/matal/store/service/StoreServiceTest.java
@@ -1,11 +1,11 @@
 package matal.store.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import matal.store.dto.StoreInfoResponseDto;
 import matal.store.dto.StoreResponseDto;
@@ -35,11 +35,11 @@ public class StoreServiceTest {
 
     @BeforeEach
     void setUp() {
-        store1 = createStore(1L, "Test Store1", "Address 1", "Station 1");
-        store2 = createStore(2L, "Test Store2", "Address 2", "Station 2");
+        store1 = createStore(1L, "Test Store1", "Address 1", "Station 1", 4.5);
+        store2 = createStore(2L, "Test Store2", "Address 2", "Station 2", 4.0);
     }
 
-    private Store createStore(Long id, String name, String address, String nearbyStation) {
+    private Store createStore(Long id, String name, String address, String nearbyStation, Double rating) {
         return Store.builder()
                 .id(id)
                 .keyword("Test")
@@ -55,7 +55,7 @@ public class StoreServiceTest {
                 .longitude(11.11)
                 .positive_keywords("good")
                 .review_summary("summary")
-                .rating(4.5)
+                .rating(rating)
                 .positive_ratio(93.0)
                 .negative_ratio(7.0)
                 .build();
@@ -97,8 +97,8 @@ public class StoreServiceTest {
     @DisplayName("가게 주변 역을 이용한 목록 조회 테스트")
     void testStoreStationSearch() {
         // given
-        store1 = createStore(1L, "Test Store1", "Address 1", "부산역 3번 출구로 부터 10m");
-        store2 = createStore(2L, "Test Store2", "Address 2", "부산역 2번 출구로부터 30m");
+        store1 = createStore(1L, "Test Store1", "Address 1", "부산역 3번 출구로 부터 10m", 4.5);
+        store2 = createStore(2L, "Test Store2", "Address 2", "부산역 2번 출구로부터 30m", 4.0);
         List<Store> stores = List.of(store1, store2);
 
         // when
@@ -125,5 +125,21 @@ public class StoreServiceTest {
         assertNotNull(response);
         assertEquals(response.name(), store2.getName());
         assertEquals(response.address(), store2.getAddress());
+    }
+
+    @Test
+    @DisplayName("별점을 기준으로 오름차순 혹은 내림차순으로 정렬하는 테스트")
+    void testStoreSort() {
+        //given
+        List<Store> stores = List.of(store1, store2);
+        List<StoreResponseDto> storeResponseDto = stores.stream().map(StoreResponseDto::from).collect(Collectors.toList());
+
+        //when
+        List<StoreResponseDto> responses = storeService.sortStores(storeResponseDto, "rating", "upper");
+
+        //then
+        assertNotNull(responses);
+        assertEquals(responses.get(0).id(), 2L);
+        assertTrue(responses.get(0).rating() <= responses.get(1).rating());
     }
 }

--- a/src/test/java/matal/store/service/StoreServiceTest.java
+++ b/src/test/java/matal/store/service/StoreServiceTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
+
+import matal.store.dto.StoreInfoResponseDto;
 import matal.store.dto.StoreResponseDto;
 import matal.store.entity.Store;
 import matal.store.repository.StoreRepository;
@@ -107,5 +109,21 @@ public class StoreServiceTest {
         assertNotNull(responses);
         assertEquals(responses.get(0).address(), store1.getAddress());
         assertEquals(responses.get(1).address(), store2.getAddress());
+    }
+
+    @Test
+    @DisplayName("가게 클릭 시, 가게 번호를 검색하여 가게 상세 정보 조회 테스트")
+    void testStoreInfoGet() {
+        //given
+        List<Store> stores = List.of(store1, store2);
+
+        //when
+        when(storeRepository.findById(2L)).thenReturn(Optional.of(store2));
+        StoreInfoResponseDto response = storeService.getStoreInfo(2L);
+
+        //then
+        assertNotNull(response);
+        assertEquals(response.name(), store2.getName());
+        assertEquals(response.address(), store2.getAddress());
     }
 }


### PR DESCRIPTION
## 개요

- 사용자는 원하는 한 가게의 상세 정보를 조회할 수 있다.
- 사용자는 검색 결과로 나온 가게의 리스트를 긍정비율, 별점, 리뷰수를 기준으로 각각 오름차순, 내림차순으로 정렬할 수 있다.

### PR 타입

- 기능 추가

### 변경 사항

- StoreInfoResponseDto 생성
- StoreResponseDto에 positive_ratio 추가
- StoreService에서 로직 처리
- StoreController를 통해 API 엔드 포인트 구현
- StoreController에서 검색 api와 정렬 api 조합


### 테스트 결과

- [O] 상세 정보 조회 기능 테스트
- [O] 정렬 기능 테스트