### PR TITLE
refactor: 가게정보 대표 메뉴 컬럼명 변경

### DIFF
--- a/src/main/java/matal/store/dto/StoreResponseDto.java
+++ b/src/main/java/matal/store/dto/StoreResponseDto.java
@@ -46,7 +46,7 @@ public record StoreResponseDto(Long storeId,
                 storeInfo.getBusinessHours(),
                 storeInfo.getLatitude(),
                 storeInfo.getLongitude(),
-                storeInfo.getMenuAndPrice(),
+                storeInfo.getMainMenu(),
                 storeInfo.getImageUrls(),
                 reviewInsight.getPositiveKeywords(),
                 reviewInsight.getNegativeKeywords(),
@@ -61,7 +61,7 @@ public record StoreResponseDto(Long storeId,
                 reviewInsight.getIsWaiting(),
                 reviewInsight.getWaitingTip(),
                 reviewInsight.getIsPetFriendly(),
-                reviewInsight.getRecommendMenu()
+                reviewInsight.getRecommendedMenu()
         );
     }
 }

--- a/src/main/java/matal/store/entity/StoreInfo.java
+++ b/src/main/java/matal/store/entity/StoreInfo.java
@@ -48,8 +48,8 @@ public class StoreInfo {
     @Column(nullable = false)
     private Double longitude;
 
-    @Column(name = "menu_and_price", nullable = false)
-    private String menuAndPrice;
+    @Column(name = "main_menu", nullable = false, length = 1000)
+    private String mainMenu;
 
     @Column(name = "image_urls", nullable = false, length = 1000)
     private String imageUrls;
@@ -67,7 +67,7 @@ public class StoreInfo {
                      String businessHours,
                      Double latitude,
                      Double longitude,
-                     String menuAndPrice,
+                     String mainMenu,
                      String imageUrls) {
         this.storeId = storeId;
         this.keyword = keyword;
@@ -81,7 +81,7 @@ public class StoreInfo {
         this.businessHours = businessHours;
         this.latitude = latitude;
         this.longitude = longitude;
-        this.menuAndPrice = menuAndPrice;
+        this.mainMenu = mainMenu;
         this.imageUrls = imageUrls;
     }
 }

--- a/src/main/java/matal/store/entity/StoreReviewInsight.java
+++ b/src/main/java/matal/store/entity/StoreReviewInsight.java
@@ -27,8 +27,8 @@ public class StoreReviewInsight {
     @JoinColumn(name = "store_info_id")
     private StoreInfo storeInfo;
 
-    @Column(name = "recommended_menu", nullable = false, length = 500)
-    private String recommendMenu;
+    @Column(name = "recommended_menu", nullable = false, length = 1000)
+    private String recommendedMenu;
 
     @Column(name = "positive_keywords", nullable = false)
     private String positiveKeywords;
@@ -57,13 +57,13 @@ public class StoreReviewInsight {
     @Column(name = "parking", nullable = false)
     private Boolean isParking;
 
-    @Column(name = "parking_tip", nullable = false, length = 500)
+    @Column(name = "parking_tip", nullable = false, length = 1000)
     private String parkingTip;
 
     @Column(name = "waiting", nullable = false)
     private Boolean isWaiting;
 
-    @Column(name = "waiting_tip", nullable = false, length = 500)
+    @Column(name = "waiting_tip", nullable = false, length = 1000)
     private String waitingTip;
 
     @Column(name = "pet_friendly", nullable = false)
@@ -72,7 +72,7 @@ public class StoreReviewInsight {
     @Builder
     public StoreReviewInsight(Long storeId,
                               StoreInfo storeInfo,
-                              String recommendMenu,
+                              String recommendedMenu,
                               String positiveKeywords,
                               String negativeKeywords,
                               String reviewSummary,
@@ -88,7 +88,7 @@ public class StoreReviewInsight {
                               Boolean isPetFriendly) {
         this.storeId = storeId;
         this.storeInfo = storeInfo;
-        this.recommendMenu = recommendMenu;
+        this.recommendedMenu = recommendedMenu;
         this.positiveKeywords = positiveKeywords;
         this.negativeKeywords = negativeKeywords;
         this.reviewSummary = reviewSummary;

--- a/src/test/java/matal/store/service/StoreInfoServiceTest.java
+++ b/src/test/java/matal/store/service/StoreInfoServiceTest.java
@@ -62,7 +62,7 @@ public class StoreInfoServiceTest {
                 .businessHours("9-23")
                 .latitude(12.4)
                 .longitude(11.11)
-                .menuAndPrice("계절 숙성 사시미 (소) - 50,000원, 홍가리비찜 - 25,000원, 미나리조개탕 - 23,000원")
+                .mainMenu("계절 숙성 사시미 (소) - 50,000원, 홍가리비찜 - 25,000원, 미나리조개탕 - 23,000원")
                 .imageUrls("https://example.com/image.jpg")
                 .build();
     }
@@ -84,7 +84,7 @@ public class StoreInfoServiceTest {
                 .isWaiting(false)
                 .waitingTip("대기 없음")
                 .isPetFriendly(true)
-                .recommendMenu("홍가리비찜")
+                .recommendedMenu("홍가리비찜")
                 .build();
     }
 


### PR DESCRIPTION
### 개요

- 데이터 수집 컬럼명에 따른 가게 정보 컬럼명 변경 요구

### 반영 브랜치

- `refactor/domain-2` -> `main`

### PR 타입

- 리팩터링

### 변경 사항

- StoreInfo menuAndPrice 컬럼명을 mainMenu로 변경
- StoreInfoResponseDto의 컬럼명 변경
- StoreReviewInsight 컬럼명 변경

### 테스트 결과

- [X] 테스트 빌드 통과