### PR TITLE
refactor: top10 API 추가, REGEXP 쿼리 수정

### DIFF
--- a/src/main/java/matal/store/controller/StoreController.java
+++ b/src/main/java/matal/store/controller/StoreController.java
@@ -127,4 +127,16 @@ public class StoreController {
                 (isWaiting == null) &&
                 (isPetFriendly == null);
     }
+
+    @GetMapping("/top")
+    @Operation(summary = "상위 10개의 가게 조회", description = "별점, 긍정비율 순으로 정렬했을 때 상위 10개의 가게 조회")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = {@Content(schema = @Schema(implementation = StoreResponseDto.class))}),
+            @ApiResponse(responseCode = "404", description = "실패"),
+    })
+    private Page<StoreListResponseDto> getStoretop() {
+        return storeService.findTop();
+    }
+
 }

--- a/src/main/java/matal/store/controller/StoreController.java
+++ b/src/main/java/matal/store/controller/StoreController.java
@@ -26,9 +26,9 @@ public class StoreController {
     @GetMapping("/searchAndFilter")
     public Page<StoreListResponseDto> searchAndFilterStores(
             @RequestParam(required = false) String searchKeywords,
-            @RequestParam(required = false) String category,
+            @RequestParam(required = false) List<String> category,
             @RequestParam(required = false) List<String> addresses,
-            @RequestParam(required = false) String positiveKeyword,
+            @RequestParam(required = false) List<String> positiveKeyword,
             @RequestParam(required = false) Double positiveRatio,
             @RequestParam(required = false) Long reviewsCount,
             @RequestParam(required = false) Double rating,
@@ -57,9 +57,9 @@ public class StoreController {
 
         return storeService.searchAndFilterStores(
                 searchKeywords,
-                category,
+                convertListToString(category),
                 convertListToString(addresses),
-                positiveKeyword,
+                convertListToString(positiveKeyword),
                 positiveRatio,
                 reviewsCount,
                 rating,
@@ -104,9 +104,9 @@ public class StoreController {
     }
 
     private boolean isAllParametersNullOrEmpty(String searchKeywords,
-                                               String category,
+                                               List<String> category,
                                                List<String> addresses,
-                                               String positiveKeyword,
+                                               List<String> positiveKeyword,
                                                Double positiveRatio,
                                                Long reviewsCount,
                                                Double rating,

--- a/src/main/java/matal/store/repository/StoreRepository.java
+++ b/src/main/java/matal/store/repository/StoreRepository.java
@@ -11,9 +11,9 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 
     @Query(value = "SELECT * FROM store WHERE " +
             "(:searchKeywords IS NULL OR MATCH(keyword, name, category, address, nearby_station, main_menu, positive_keywords, review_summary, recommended_menu) AGAINST (:searchKeywords IN BOOLEAN MODE)) AND " +
-            "(:category IS NULL OR category = :category) AND " +
+            "(:category IS NULL OR category REGEXP :category) AND " +
             "(:addresses IS NULL OR address REGEXP :addresses) AND " +
-            "(:positiveKeyword IS NULL OR positive_keywords LIKE %:positiveKeyword%) AND " +
+            "(:positiveKeyword IS NULL OR positive_keywords REGEXP :positiveKeyword) AND " +
             "(:positiveRatio IS NULL OR positive_ratio >= :positiveRatio) AND " +
             "(:reviewsCount IS NULL OR reviews_count >= :reviewsCount) AND " +
             "(:rating IS NULL OR rating >= :rating) AND " +

--- a/src/main/java/matal/store/service/StoreService.java
+++ b/src/main/java/matal/store/service/StoreService.java
@@ -8,6 +8,7 @@ import matal.store.repository.StoreRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,6 +63,13 @@ public class StoreService {
 
     public Page<StoreListResponseDto> findAll(int page) {
         Pageable pageable = PageRequest.of(page, 10);
+        return storeRepository.findAll(pageable).map(StoreListResponseDto::from);
+    }
+
+    public Page<StoreListResponseDto> findTop() {
+        Sort sortAll = Sort.by("rating").descending()
+                .and(Sort.by("positiveRatio").descending());
+        Pageable pageable = PageRequest.of(0, 10, sortAll);
         return storeRepository.findAll(pageable).map(StoreListResponseDto::from);
     }
 }

--- a/src/test/java/matal/store/controller/StoreControllerTest.java
+++ b/src/test/java/matal/store/controller/StoreControllerTest.java
@@ -275,4 +275,34 @@ public class StoreControllerTest {
                 .andExpect(jsonPath("$.name").value(storeDetail.name()))
                 .andExpect(jsonPath("$.address").value(storeDetail.address()));
     }
+
+    @Test
+    @DisplayName("top10 가게 조회 기능 테스트")
+    @WithMockUser(username = "test", roles = "USER")
+    void testGetStoreTop() throws Exception {
+        //given
+        List<StoreListResponseDto> topStores = List.of(
+                stores.get(4),
+                stores.get(2),
+                stores.get(0),
+                stores.get(6),
+                stores.get(5),
+                stores.get(1),
+                stores.get(7),
+                stores.get(8),
+                stores.get(3),
+                stores.get(9));
+
+        Page<StoreListResponseDto> storePage = new PageImpl<>(topStores);
+        when(storeService.findTop()).thenReturn(storePage);
+
+        //when & then
+        mockMvc.perform(get("/api/stores/top")
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                        .contentType("application/json"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].name").value(stores.get(4).name()))
+                .andExpect(jsonPath("$.content[1].name").value(stores.get(2).name()))
+                .andExpect(jsonPath("$.content[2].name").value(stores.get(0).name()));
+    }
 }

--- a/src/test/java/matal/store/service/StoreServiceTest.java
+++ b/src/test/java/matal/store/service/StoreServiceTest.java
@@ -3,6 +3,7 @@ package matal.store.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
+import java.awt.*;
 import java.util.List;
 import java.util.Optional;
 
@@ -274,5 +275,40 @@ public class StoreServiceTest {
 
         assertEquals(responseDtos.getContent().get(3).latitude(), store2.getLatitude());
         assertEquals(responseDtos.getContent().get(3).longitude(), store3.getLongitude());
+    }
+
+    @Test
+    @DisplayName("별점순, 긍정비율순 top 10 가게 목록 조회 테스트")
+    void testFindTop() {
+        //given
+        List<Store> topStores = List.of(
+                store8,
+                store3,
+                store5,
+                store6,
+                store1,
+                store9,
+                store7,
+                store2,
+                store4,
+                store10);
+
+        Sort sortAll = Sort.by("rating").descending()
+                .and(Sort.by("positiveRatio").descending());
+        Pageable pageable = PageRequest.of(0, 10, sortAll);
+        Page<Store> topStorePage = new PageImpl<>(topStores, pageable, topStores.size());
+
+        //when
+        when(storeRepository.findAll(pageable)).thenReturn(topStorePage);
+
+        Page<StoreListResponseDto> responseDtos = storeService.findTop();
+
+        //then
+        assertNotNull(responseDtos);
+        assertEquals(topStores.size(), responseDtos.getTotalElements());
+        assertEquals(responseDtos.getContent().get(0).address(), store8.getAddress());
+        assertEquals(responseDtos.getContent().get(0).name(), store8.getName());
+        assertEquals(responseDtos.getContent().get(2).address(), store5.getAddress());
+        assertEquals(responseDtos.getContent().get(2).name(), store5.getName());
     }
 }


### PR DESCRIPTION
## 개요

- 별점순, 긍정비율 순 상위 10개의 가게를 조회한다.
- 필터를 다중 선택할 수 있다.

### PR 타입

- 기능 추가
- 리팩터링

### 변경 사항

- StoreService의 findTop으로 정렬, 페이징 로직 구현
- StoreController 상위 10개 가게 조회하는 API 추가
- StoreRepository category, positiveKeyword 쿼리 REGEXP 수정
- StoreController category, positiveKeyword 타입 List<String> 변환

### 테스트 결과

- [X] top10 API Swagger, H2 테스트 