### PR TITLE
refactor: 회원 컬럼명 및 ddl-auto validate 수정

### DIFF
--- a/src/main/java/matal/member/domain/Member.java
+++ b/src/main/java/matal/member/domain/Member.java
@@ -14,6 +14,7 @@ public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
     private Long memberId;
 
     @Column(nullable = false)


### PR DESCRIPTION
## 개요

- MYSQL 테이블과 컬럼명을 일치시키고, 테이블의 변경을 막도록 변경

### PR 타입

- 리팩터링
- 운영 서버 환경변수 변경

### 반영 브랜치

- refactor/session-1 -> main

## 변경 사항

- ddl-auto 설정을 update에서 validate 로 변경
- member id 컬럼명을 지정

### 테스트 결과

- [X] 정상 작동 확인