### PR TITLE
refactor: 동적 쿼리 조회 추가

### DIFF
--- a/src/main/java/matal/store/domain/repository/StoreRepository.java
+++ b/src/main/java/matal/store/domain/repository/StoreRepository.java
@@ -1,56 +1,8 @@
 package matal.store.domain.repository;
 
 import matal.store.domain.Store;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface StoreRepository extends JpaRepository<Store, Long> {
-
-    @Query(value = "SELECT * FROM store WHERE " +
-            "(:searchKeywords IS NULL OR MATCH(keyword, name, category, address, nearby_station, main_menu, positive_keywords, review_summary, recommended_menu) AGAINST (:searchKeywords IN BOOLEAN MODE)) AND " +
-            "(:category IS NULL OR category REGEXP :category) AND " +
-            "(:addresses IS NULL OR address REGEXP :addresses) AND " +
-            "(:positiveKeyword IS NULL OR positive_keywords REGEXP :positiveKeyword) AND " +
-            "(:positiveRatio IS NULL OR positive_ratio >= :positiveRatio) AND " +
-            "(:reviewsCount IS NULL OR reviews_count >= :reviewsCount) AND " +
-            "(:rating IS NULL OR rating >= :rating) AND " +
-            "(:soloDining IS NULL OR solo_dining = :soloDining) AND " +
-            "(:parking IS NULL OR parking = :parking) AND " +
-            "(:waiting IS NULL OR waiting = :waiting) AND " +
-            "(:petFriendly IS NULL OR pet_friendly = :petFriendly) " +
-            "ORDER BY " +
-            "CASE WHEN :orderByRating = 'ASC' THEN rating END ASC, " +
-            "CASE WHEN :orderByRating = 'DESC' THEN rating END DESC, " +
-            "CASE WHEN :orderByPositiveRatio = 'ASC' THEN positive_ratio END ASC, " +
-            "CASE WHEN :orderByPositiveRatio = 'DESC' THEN positive_ratio END DESC",
-            nativeQuery = true)
-    Page<Store> searchAndFilterStores(
-            @Param("searchKeywords") String searchKeywords,
-            @Param("category") String category,
-            @Param("addresses") String addresses,
-            @Param("positiveKeyword") String positiveKeyword,
-            @Param("positiveRatio") Double positiveRatio,
-            @Param("reviewsCount") Long reviewsCount,
-            @Param("rating") Double rating,
-            @Param("soloDining") Boolean soloDining,
-            @Param("parking") Boolean parking,
-            @Param("waiting") Boolean waiting,
-            @Param("petFriendly") Boolean petFriendly,
-            @Param("orderByRating") String orderByRating,
-            @Param("orderByPositiveRatio") String orderByPositiveRatio,
-            Pageable pageable);
-
-    @Query(value = "SELECT * FROM store " +
-            "ORDER BY " +
-            "CASE WHEN :orderByRating = 'ASC' THEN rating END ASC, " +
-            "CASE WHEN :orderByRating = 'DESC' THEN rating END DESC, " +
-            "CASE WHEN :orderByPositiveRatio = 'ASC' THEN positive_ratio END ASC, " +
-            "CASE WHEN :orderByPositiveRatio = 'DESC' THEN positive_ratio END DESC",
-            nativeQuery = true)
-    Page<Store> findAllOrderByRatingOrPositiveRatio(@Param("orderByRating") String orderByRating,
-                                                    @Param("orderByPositiveRatio") String orderByPositiveRatio,
-                                                    Pageable pageable);
+public interface StoreRepository extends JpaRepository<Store, Long>, JpaSpecificationExecutor<Store> {
 }

--- a/src/main/java/matal/store/domain/repository/StoreSpecification.java
+++ b/src/main/java/matal/store/domain/repository/StoreSpecification.java
@@ -1,0 +1,63 @@
+package matal.store.domain.repository;
+
+import jakarta.persistence.criteria.Predicate;
+import matal.store.domain.Store;
+import matal.store.dto.request.StoreSearchFilterRequestDto;
+import org.springframework.data.jpa.domain.Specification;
+import java.util.ArrayList;
+import java.util.List;
+
+public class StoreSpecification {
+    public static Specification<Store> withFilters(StoreSearchFilterRequestDto filter) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            if (filter.getSearchKeywords() != null) {
+                predicates.add(cb.like(root.get("keyword"), "%" + filter.getSearchKeywords() + "%"));
+            }
+
+            if (filter.getCategory() != null) {
+                predicates.add(cb.equal(root.get("category"), filter.getCategory()));
+            }
+
+            if (filter.getAddresses() != null) {
+                predicates.add(cb.like(root.get("address"), "%" + filter.getAddresses() + "%"));
+            }
+
+            if (filter.getPositiveKeyword() != null) {
+                predicates.add(cb.like(root.get("positive_keywords"), "%" + filter.getPositiveKeyword() + "%"));
+            }
+
+            if (filter.getPositiveRatio() != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("positive_ratio"), filter.getPositiveRatio()));
+            }
+
+            if (filter.getReviewsCount() != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("reviews_count"), filter.getReviewsCount()));
+            }
+
+            if (filter.getRating() != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("rating"), filter.getRating()));
+            }
+
+            if (filter.getIsSoloDining() != null) {
+                predicates.add(cb.equal(root.get("solodining"), filter.getIsSoloDining()));
+            }
+
+            if (filter.getIsParking() != null) {
+                predicates.add(cb.equal(root.get("parking"), filter.getIsParking()));
+            }
+
+            if (filter.getIsWaiting() != null) {
+                predicates.add(cb.equal(root.get("waiting"), filter.getIsWaiting()));
+            }
+
+            if (filter.getIsPetFriendly() != null) {
+                predicates.add(cb.equal(root.get("petfriendly"), filter.getIsPetFriendly()));
+            }
+
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+}

--- a/src/main/java/matal/store/domain/repository/originStoreRepository.java
+++ b/src/main/java/matal/store/domain/repository/originStoreRepository.java
@@ -1,0 +1,56 @@
+package matal.store.domain.repository;
+
+import matal.store.domain.Store;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface originStoreRepository extends JpaRepository<Store, Long> {
+
+    @Query(value = "SELECT * FROM store WHERE " +
+            "(:searchKeywords IS NULL OR MATCH(keyword, name, category, address, nearby_station, main_menu, positive_keywords, review_summary, recommended_menu) AGAINST (:searchKeywords IN BOOLEAN MODE)) AND " +
+            "(:category IS NULL OR category REGEXP :category) AND " +
+            "(:addresses IS NULL OR address REGEXP :addresses) AND " +
+            "(:positiveKeyword IS NULL OR positive_keywords REGEXP :positiveKeyword) AND " +
+            "(:positiveRatio IS NULL OR positive_ratio >= :positiveRatio) AND " +
+            "(:reviewsCount IS NULL OR reviews_count >= :reviewsCount) AND " +
+            "(:rating IS NULL OR rating >= :rating) AND " +
+            "(:soloDining IS NULL OR solo_dining = :soloDining) AND " +
+            "(:parking IS NULL OR parking = :parking) AND " +
+            "(:waiting IS NULL OR waiting = :waiting) AND " +
+            "(:petFriendly IS NULL OR pet_friendly = :petFriendly) " +
+            "ORDER BY " +
+            "CASE WHEN :orderByRating = 'ASC' THEN rating END ASC, " +
+            "CASE WHEN :orderByRating = 'DESC' THEN rating END DESC, " +
+            "CASE WHEN :orderByPositiveRatio = 'ASC' THEN positive_ratio END ASC, " +
+            "CASE WHEN :orderByPositiveRatio = 'DESC' THEN positive_ratio END DESC",
+            nativeQuery = true)
+    Page<Store> searchAndFilterStores(
+            @Param("searchKeywords") String searchKeywords,
+            @Param("category") String category,
+            @Param("addresses") String addresses,
+            @Param("positiveKeyword") String positiveKeyword,
+            @Param("positiveRatio") Double positiveRatio,
+            @Param("reviewsCount") Long reviewsCount,
+            @Param("rating") Double rating,
+            @Param("soloDining") Boolean soloDining,
+            @Param("parking") Boolean parking,
+            @Param("waiting") Boolean waiting,
+            @Param("petFriendly") Boolean petFriendly,
+            @Param("orderByRating") String orderByRating,
+            @Param("orderByPositiveRatio") String orderByPositiveRatio,
+            Pageable pageable);
+
+    @Query(value = "SELECT * FROM store " +
+            "ORDER BY " +
+            "CASE WHEN :orderByRating = 'ASC' THEN rating END ASC, " +
+            "CASE WHEN :orderByRating = 'DESC' THEN rating END DESC, " +
+            "CASE WHEN :orderByPositiveRatio = 'ASC' THEN positive_ratio END ASC, " +
+            "CASE WHEN :orderByPositiveRatio = 'DESC' THEN positive_ratio END DESC",
+            nativeQuery = true)
+    Page<Store> findAllOrderByRatingOrPositiveRatio(@Param("orderByRating") String orderByRating,
+                                                    @Param("orderByPositiveRatio") String orderByPositiveRatio,
+                                                    Pageable pageable);
+}

--- a/src/main/java/matal/store/service/StoreService.java
+++ b/src/main/java/matal/store/service/StoreService.java
@@ -1,19 +1,19 @@
 package matal.store.service;
-
-import lombok.RequiredArgsConstructor;
 import matal.global.exception.NotFoundException;
 import matal.global.exception.ResponseCode;
+import matal.store.domain.Store;
+import matal.store.domain.repository.StoreRepository;
+import matal.store.domain.repository.StoreSpecification;
 import matal.store.dto.request.StoreSearchFilterRequestDto;
 import matal.store.dto.response.StoreListResponseDto;
 import matal.store.dto.response.StoreResponseDto;
-import matal.store.domain.Store;
-import matal.store.domain.repository.StoreRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional(readOnly = true)
@@ -23,45 +23,25 @@ public class StoreService {
     private final StoreRepository storeRepository;
 
     public Page<StoreListResponseDto> searchAndFilterStores(StoreSearchFilterRequestDto filterRequestDto) {
-
         Pageable pageable = PageRequest.of(filterRequestDto.getPage(), 10);
 
-        return storeRepository.searchAndFilterStores(
-                filterRequestDto.getSearchKeywords(),
-                filterRequestDto.convertCategoryToString(),
-                filterRequestDto.convertAddressesToString(),
-                filterRequestDto.convertPositiverKeywordsToString(),
-                filterRequestDto.getPositiveRatio(),
-                filterRequestDto.getReviewsCount(),
-                filterRequestDto.getRating(),
-                filterRequestDto.getIsSoloDining(),
-                filterRequestDto.getIsParking(),
-                filterRequestDto.getIsWaiting(),
-                filterRequestDto.getIsPetFriendly(),
-                filterRequestDto.getOrderByRating(),
-                filterRequestDto.getOrderByPositiveRatio(),
-                pageable
-        ).map(StoreListResponseDto::from);
+        Specification<Store> spec = StoreSpecification.withFilters(filterRequestDto);
+
+        return storeRepository.findAll(spec, pageable).map(StoreListResponseDto::from);
     }
 
     public StoreResponseDto findById(Long storeId) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new NotFoundException(ResponseCode.STORE_NOT_FOUND_ID));
-
         return StoreResponseDto.from(store);
     }
 
-    public Page<StoreListResponseDto> findAll(int page,
-                                              String orderByRatio,
-                                              String orderByPositiveRatio) {
-        Pageable pageable = PageRequest.of(page, 10);
-        return storeRepository.findAllOrderByRatingOrPositiveRatio(orderByRatio,orderByPositiveRatio, pageable).map(StoreListResponseDto::from);
+    public Page<StoreListResponseDto> findAll(int page, String orderByRating, String orderByPositiveRatio) {
+        return null;
     }
 
     public Page<StoreListResponseDto> findTop() {
-        Sort sortAll = Sort.by("rating").descending()
-                .and(Sort.by("positiveRatio").descending());
-        Pageable pageable = PageRequest.of(0, 10, sortAll);
-        return storeRepository.findAll(pageable).map(StoreListResponseDto::from);
+        return null;
     }
 }
+

--- a/src/main/java/matal/store/service/originStoreService.java
+++ b/src/main/java/matal/store/service/originStoreService.java
@@ -1,0 +1,69 @@
+package matal.store.service;
+
+import lombok.RequiredArgsConstructor;
+import matal.global.exception.NotFoundException;
+import matal.global.exception.ResponseCode;
+import matal.store.domain.repository.originStoreRepository;
+import matal.store.dto.request.StoreSearchFilterRequestDto;
+import matal.store.dto.response.StoreListResponseDto;
+import matal.store.dto.response.StoreResponseDto;
+import matal.store.domain.Store;
+import matal.store.domain.repository.StoreRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class originStoreService {
+
+//    private final StoreRepository storeRepository;
+    private final originStoreRepository originStoreRepository;
+
+    public Page<StoreListResponseDto> searchAndFilterStores(StoreSearchFilterRequestDto filterRequestDto) {
+
+        Pageable pageable = PageRequest.of(filterRequestDto.getPage(), 10);
+
+        return originStoreRepository.searchAndFilterStores(
+                filterRequestDto.getSearchKeywords(),
+                filterRequestDto.convertCategoryToString(),
+                filterRequestDto.convertAddressesToString(),
+                filterRequestDto.convertPositiverKeywordsToString(),
+                filterRequestDto.getPositiveRatio(),
+                filterRequestDto.getReviewsCount(),
+                filterRequestDto.getRating(),
+                filterRequestDto.getIsSoloDining(),
+                filterRequestDto.getIsParking(),
+                filterRequestDto.getIsWaiting(),
+                filterRequestDto.getIsPetFriendly(),
+                filterRequestDto.getOrderByRating(),
+                filterRequestDto.getOrderByPositiveRatio(),
+                pageable
+        ).map(StoreListResponseDto::from);
+    }
+
+    public StoreResponseDto findById(Long storeId) {
+        Store store = originStoreRepository.findById(storeId)
+                .orElseThrow(() -> new NotFoundException(ResponseCode.STORE_NOT_FOUND_ID));
+
+        return StoreResponseDto.from(store);
+    }
+
+    public Page<StoreListResponseDto> findAll(int page,
+                                              String orderByRatio,
+                                              String orderByPositiveRatio) {
+        Pageable pageable = PageRequest.of(page, 10);
+        return originStoreRepository.findAllOrderByRatingOrPositiveRatio(orderByRatio,orderByPositiveRatio, pageable).map(StoreListResponseDto::from);
+    }
+    public Page<StoreListResponseDto> findTop() {
+        Sort sortAll = Sort.by("rating").descending()
+                .and(Sort.by("positiveRatio").descending());
+        Pageable pageable = PageRequest.of(0, 10, sortAll);
+        return originStoreRepository.findAll(pageable).map(StoreListResponseDto::from);
+    }
+}
+


### PR DESCRIPTION
- 데이터베이스에서 동적 쿼리 조회 가능하도록 JpaSpecificationExecutor를 사용
- 기존 레포지토리와 서비스 코드를 구분하기 위해 'origin' 추가 예) originStoreService
- 특정 조건에 해당 하는 정보를 조회하는데 최적화를 우선으로 해서 findall, findbyid는 수정하지 않음.
- 동적 쿼리 조회 테스트를 위해 dynamictestSearchAndFilterStores서비스 테스트 추가


StoreServiceTest 테스트 중에서 testSearchAndFilterStores, dynamictestSearchAndFilterStores 제외한 테스트 코드는 수정하지 않았습니다. 