### PR TITLE
refactor: 북마크 생성 시 AuthMember 파라미터 객체 숨김

### DIFF
--- a/src/main/java/matal/bookmark/controller/BookmarkController.java
+++ b/src/main/java/matal/bookmark/controller/BookmarkController.java
@@ -1,6 +1,7 @@
 package matal.bookmark.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -40,7 +41,7 @@ public class BookmarkController {
                     content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
             @ApiResponse(responseCode = "404", description = "가게 조회 실패",
                     content = {@Content(schema = @Schema(implementation = ErrorResponse.class))})})
-    public ResponseEntity<Void> createBookmark(@LoginMember AuthMember authMember, @RequestBody Long storeId) {
+    public ResponseEntity<Void> createBookmark(@LoginMember @Parameter(hidden = true) AuthMember authMember, @RequestBody Long storeId) {
         bookmarkService.saveBookmark(authMember, storeId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/matal/bookmark/controller/BookmarkController.java
+++ b/src/main/java/matal/bookmark/controller/BookmarkController.java
@@ -55,7 +55,7 @@ public class BookmarkController {
                     content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
             @ApiResponse(responseCode = "404", description = "회원 조회 실패",
                     content = {@Content(schema = @Schema(implementation = ErrorResponse.class))})})
-    public ResponseEntity<List<BookmarkResponseDto>> getBookmarks(@LoginMember AuthMember authMember) {
+    public ResponseEntity<List<BookmarkResponseDto>> getBookmarks(@LoginMember @Parameter(hidden = true) AuthMember authMember) {
         List<BookmarkResponseDto> bookmarkResponse = bookmarkService.getBookmarks(authMember);
         return ResponseEntity.ok(bookmarkResponse);
     }
@@ -69,7 +69,7 @@ public class BookmarkController {
                     content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
             @ApiResponse(responseCode = "404", description = "북마크 정보 조회 실패",
                     content = {@Content(schema = @Schema(implementation = ErrorResponse.class))})})
-    public ResponseEntity<Void> deleteBookmark(@LoginMember AuthMember authMember, @PathVariable Long id) {
+    public ResponseEntity<Void> deleteBookmark(@LoginMember @Parameter(hidden = true) AuthMember authMember, @PathVariable Long id) {
         bookmarkService.deleteBookmark(authMember, id);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }


### PR DESCRIPTION
## 개요

- 북마크 관련 API에서 세션 정보를 RequestBody로 인식하는 문제

### PR 타입

- 버그 수정

### 반영 브랜치

- fix/50-bookmark-memberid -> main

## 변경 사항

- @Parameter(hidden = true)를 AuthMember 객체에 적용

### 테스트 결과

- [X] 로컬의 스웨거를 통해 AuthMemver 객체의 정보 받는 것이 사라진 것을 확인