### PR TITLE
fix: authMember이 null일 경우 예외처리 진행

### DIFF
--- a/src/main/java/matal/global/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/matal/global/auth/LoginMemberArgumentResolver.java
@@ -13,6 +13,8 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
 
+    private static final String SESSION_KEY = "member";
+
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(LoginMember.class) &&
@@ -30,6 +32,11 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
         if (session == null) {
             throw new AuthException(ResponseCode.SESSION_AUTH_EXCEPTION);
         }
-        return session.getAttribute("member");
+
+        Object authMember = session.getAttribute(SESSION_KEY);
+        if (authMember == null) {
+            throw new AuthException(ResponseCode.SESSION_AUTH_EXCEPTION); // 세션에 "member"가 없을 때 예외
+        }
+        return authMember;
     }
 }


### PR DESCRIPTION
## 개요

- 로그인 하지 않은 채로 북마크 조회 시 `NullPointerException` 발생

### PR 타입

- 버그 수정

### 반영 브랜치

- fix/52-authmember-null-exception -> main

## 변경 사항

- `SESSION_VALUE_EXCEPTION` 추가
- 커스텀 예외처리 진행
- Object 형태로 변환 후 NullPointer 예외 처리 진행

### 테스트 결과

- [X] 정상 테스트 확인