### PR TITLE
fix: authMember이 null일 경우 예외처리 진행

### DIFF
--- a/src/main/java/matal/global/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/matal/global/auth/LoginMemberArgumentResolver.java
@@ -13,6 +13,8 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
 
+    private static final String SESSION_KEY = "member";
+
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(LoginMember.class) &&
@@ -28,8 +30,13 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
         HttpSession session = request.getSession(false);
         if (session == null) {
+            throw new AuthException(ResponseCode.SESSION_VALUE_EXCEPTION);
+        }
+
+        Object authMember = session.getAttribute(SESSION_KEY);
+        if (authMember == null) {
             throw new AuthException(ResponseCode.SESSION_AUTH_EXCEPTION);
         }
-        return session.getAttribute("member");
+        return authMember;
     }
 }

--- a/src/main/java/matal/global/exception/ResponseCode.java
+++ b/src/main/java/matal/global/exception/ResponseCode.java
@@ -14,13 +14,14 @@ public enum ResponseCode {
     /*
     * member & session
      */
-    SESSION_AUTH_EXCEPTION(HttpStatus.UNAUTHORIZED, "세션 정보가 존재하지 않습니다."),
+    SESSION_AUTH_EXCEPTION(HttpStatus.UNAUTHORIZED, "사용자 세션이 만료되었거나 유효하지 않습니다. 다시 로그인해 주세요."),
+    SESSION_VALUE_EXCEPTION(HttpStatus.UNAUTHORIZED, "세션이 존재하지 않습니다."),
 
     MEMBER_NOT_FOUND_ID(HttpStatus.NOT_FOUND, "회원 정보가 존재하지 않습니다."),
-    MEMBER_NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "일치하는 이메일이 존재하지 않습니다."),
+    MEMBER_NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "회원 정보가 존재하지 않습니다."),
     MEMBER_BAD_REQUEST(HttpStatus.BAD_REQUEST, "회원가입 정보를 올바르게 입력해주세요."),
-    MEMBER_AUTH_EXCEPTION(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
-    MEMBER_ALREADY_EXIST_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 이메일 정보입니다."),
+    MEMBER_AUTH_EXCEPTION(HttpStatus.UNAUTHORIZED, "회원정보가 일치하지 않습니다."),
+    MEMBER_ALREADY_EXIST_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 이메일 정보 입니다."),
 
     /*
     * store


### PR DESCRIPTION
## 개요

- 로그인 하지 않은 채로 북마크 조회 시 `NullPointerException` 발생

### PR 타입

- 버그 수정

### 반영 브랜치

- fix/52-authmember-null-exception -> main

## 변경 사항

- `SESSION_VALUE_EXCEPTION` 추가
- 커스텀 예외처리 진행
- Object 형태로 변환 후 NullPointer 예외 처리 진행

### 테스트 결과

- [X] 정상 테스트 확인