### PR TITLE
chore: Prometheus 의존성 추가 및 메트릭 엔드포인트 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
 
     implementation 'com.mysql:mysql-connector-j'
 
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
     compileOnly 'org.projectlombok:lombok'
 
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-core'
 
     compileOnly 'org.projectlombok:lombok'
 

--- a/src/main/java/matal/store/service/StoreService.java
+++ b/src/main/java/matal/store/service/StoreService.java
@@ -1,5 +1,9 @@
 package matal.store.service;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import matal.global.exception.NotFoundException;
 import matal.global.exception.ResponseCode;
@@ -23,47 +27,117 @@ public class StoreService {
     private static final int PAGE_SIZE = 10;
 
     private final StoreRepository storeRepository;
+    private final MeterRegistry meterRegistry;
+
+    private double lastMemoryUsage = 0;
 
     public Page<StoreListResponseDto> searchAndFilterStores(StoreSearchFilterRequestDto filterRequestDto) {
 
-        Pageable pageable = PageRequest.of(filterRequestDto.getPage(), PAGE_SIZE);
+        measureCount("store.search.count", "searchAndFilterStores");
+        measureMemory("store.search.memory", "searchAndFilterStores");
+        Timer.Sample timer = Timer.start(meterRegistry);
 
-        return storeRepository.searchAndFilterStores(
-                filterRequestDto.getSearchKeywords(),
-                filterRequestDto.convertCategoryToString(),
-                filterRequestDto.convertAddressesToString(),
-                filterRequestDto.convertPositiverKeywordsToString(),
-                filterRequestDto.getPositiveRatio(),
-                filterRequestDto.getReviewsCount(),
-                filterRequestDto.getRating(),
-                filterRequestDto.getIsSoloDining(),
-                filterRequestDto.getIsParking(),
-                filterRequestDto.getIsWaiting(),
-                filterRequestDto.getIsPetFriendly(),
-                filterRequestDto.getOrderByRating(),
-                filterRequestDto.getOrderByPositiveRatio(),
-                pageable
-        ).map(StoreListResponseDto::from);
+        try {
+            Pageable pageable = PageRequest.of(filterRequestDto.getPage(), PAGE_SIZE);
+
+            return storeRepository.searchAndFilterStores(
+                    filterRequestDto.getSearchKeywords(),
+                    filterRequestDto.convertCategoryToString(),
+                    filterRequestDto.convertAddressesToString(),
+                    filterRequestDto.convertPositiverKeywordsToString(),
+                    filterRequestDto.getPositiveRatio(),
+                    filterRequestDto.getReviewsCount(),
+                    filterRequestDto.getRating(),
+                    filterRequestDto.getIsSoloDining(),
+                    filterRequestDto.getIsParking(),
+                    filterRequestDto.getIsWaiting(),
+                    filterRequestDto.getIsPetFriendly(),
+                    filterRequestDto.getOrderByRating(),
+                    filterRequestDto.getOrderByPositiveRatio(),
+                    pageable
+            ).map(StoreListResponseDto::from);
+        } finally {
+            stopTimer(timer, "store.search.time", "searchAndFilterStores");
+        }
     }
 
     public StoreResponseDto findById(Long storeId) {
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new NotFoundException(ResponseCode.STORE_NOT_FOUND_ID));
 
-        return StoreResponseDto.from(store);
+        measureCount("store.Id.count", "findById");
+        measureMemory("store.Id.memory", "findById");
+        Timer.Sample timer = Timer.start(meterRegistry);
+
+        try {
+            Store store = storeRepository.findById(storeId)
+                    .orElseThrow(() -> new NotFoundException(ResponseCode.STORE_NOT_FOUND_ID));
+
+            return StoreResponseDto.from(store);
+        } finally {
+            stopTimer(timer, "store.Id.time", "findById");
+        }
     }
 
     public Page<StoreListResponseDto> findAll(int page,
                                               String orderByRatio,
                                               String orderByPositiveRatio) {
-        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
-        return storeRepository.findAllOrderByRatingOrPositiveRatio(orderByRatio,orderByPositiveRatio, pageable).map(StoreListResponseDto::from);
+
+        measureCount("store.all.count", "findAll");
+        measureMemory("store.all.memory", "findAll");
+        Timer.Sample timer = Timer.start(meterRegistry);
+
+        try {
+            Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+
+            return storeRepository.findAllOrderByRatingOrPositiveRatio(orderByRatio, orderByPositiveRatio, pageable).map(StoreListResponseDto::from);
+        } finally {
+            stopTimer(timer, "store.all.time", "findAll");
+        }
     }
 
     public Page<StoreListResponseDto> findTop() {
-        Sort sortAll = Sort.by("rating").descending()
-                .and(Sort.by("positiveRatio").descending());
-        Pageable pageable = PageRequest.of(0, PAGE_SIZE, sortAll);
-        return storeRepository.findAll(pageable).map(StoreListResponseDto::from);
+
+        measureCount("store.top.count", "findTop");
+        measureMemory("store.top.memory", "findTop");
+        Timer.Sample timer = Timer.start(meterRegistry);
+
+        try {
+            Sort sortAll = Sort.by("rating").descending()
+                    .and(Sort.by("positiveRatio").descending());
+            Pageable pageable = PageRequest.of(0, PAGE_SIZE, sortAll);
+
+            return storeRepository.findAll(pageable).map(StoreListResponseDto::from);
+        } finally {
+            stopTimer(timer, "store.top.time", "findTop");
+        }
+    }
+
+    private void measureMemory(String metricName, String methodName) {
+
+        Runtime runtime = Runtime.getRuntime();
+        lastMemoryUsage = (runtime.totalMemory() - runtime.freeMemory()) / (1024.0 * 1024.0);
+
+        Gauge.builder(metricName, () -> lastMemoryUsage)
+                .tag("class", this.getClass().getName())
+                .tag("metric", methodName)
+                .description("Memory usage during " + methodName)
+                .baseUnit("MB")
+                .register(meterRegistry);
+    }
+
+    private void measureCount(String metricName, String methodName) {
+        Counter.builder(metricName)
+                .tag("class", this.getClass().getName())
+                .tag("metric", methodName)
+                .description("Count of " + methodName)
+                .register(meterRegistry)
+                .increment();
+    }
+
+    private void stopTimer(Timer.Sample timer, String metricName, String methodName) {
+        timer.stop(Timer.builder(metricName)
+                .tag("class", this.getClass().getName())
+                .tag("method", methodName)
+                .description("Execution time of " + methodName)
+                .register(meterRegistry));
     }
 }


### PR DESCRIPTION
## 개요

- 애플리케이션의 메트릭을 수집할 수 있도록 의존성을 추가하고, 수집된 메드틱을 Prometheus로 전달할 수 있도록 엔드포인트와 포트를 추가로 설정한다.
- 각 api의 service별로 실행 횟수, 처리 시간을 추적할 수 있도록 커스텀 메트릭을 추가로 설정한다.
- 메모리 사용량 추적도 추가하였으나, 테스트와 리팩터링이 필요하다.

### PR 타입

- 의존성 추가
- 포트 설정, 엔드포인트 설정
 - 커스텀 메트릭 추가

## 변경 사항

- build.gradle Micrometer, actuator 의존성 추가
- 서브모듈 application.yml 엔드포인트 설정 및 포트 개방 설정
- StoreService 커스텀 메트릭 함수 적용

### 테스트 결과

- [X] 로컬환경 메트릭 데이터 출력 테스트 완료