### PR TITLE
refactor: 북마크 조회 반환 시 페이지로 반환하도록 변경

### DIFF
--- a/src/main/java/matal/bookmark/controller/BookmarkController.java
+++ b/src/main/java/matal/bookmark/controller/BookmarkController.java
@@ -7,13 +7,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import matal.bookmark.dto.response.BookmarkResponseDto;
 import matal.bookmark.service.BookmarkService;
 import matal.global.auth.LoginMember;
 import matal.global.exception.ErrorResponse;
 import matal.member.dto.request.AuthMember;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -41,7 +42,10 @@ public class BookmarkController {
                     content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
             @ApiResponse(responseCode = "404", description = "가게 조회 실패",
                     content = {@Content(schema = @Schema(implementation = ErrorResponse.class))})})
-    public ResponseEntity<Void> createBookmark(@LoginMember @Parameter(hidden = true) AuthMember authMember, @RequestBody Long storeId) {
+    public ResponseEntity<Void> createBookmark(
+            @LoginMember @Parameter(hidden = true) AuthMember authMember,
+            @RequestBody Long storeId)
+    {
         bookmarkService.saveBookmark(authMember, storeId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
@@ -55,8 +59,11 @@ public class BookmarkController {
                     content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
             @ApiResponse(responseCode = "404", description = "회원 조회 실패",
                     content = {@Content(schema = @Schema(implementation = ErrorResponse.class))})})
-    public ResponseEntity<List<BookmarkResponseDto>> getBookmarks(@LoginMember @Parameter(hidden = true) AuthMember authMember) {
-        List<BookmarkResponseDto> bookmarkResponse = bookmarkService.getBookmarks(authMember);
+    public ResponseEntity<Page<BookmarkResponseDto>> getBookmarks(
+            @LoginMember @Parameter(hidden = true) AuthMember authMember,
+            @RequestParam(name = "page", defaultValue = "0") int page)
+    {
+        Page<BookmarkResponseDto> bookmarkResponse = bookmarkService.getBookmarks(authMember, page);
         return ResponseEntity.ok(bookmarkResponse);
     }
 
@@ -69,7 +76,10 @@ public class BookmarkController {
                     content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
             @ApiResponse(responseCode = "404", description = "북마크 정보 조회 실패",
                     content = {@Content(schema = @Schema(implementation = ErrorResponse.class))})})
-    public ResponseEntity<Void> deleteBookmark(@LoginMember @Parameter(hidden = true) AuthMember authMember, @PathVariable Long id) {
+    public ResponseEntity<Void> deleteBookmark(
+            @LoginMember @Parameter(hidden = true) AuthMember authMember,
+            @PathVariable Long id)
+    {
         bookmarkService.deleteBookmark(authMember, id);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/src/main/java/matal/bookmark/domain/repository/BookmarkRepository.java
+++ b/src/main/java/matal/bookmark/domain/repository/BookmarkRepository.java
@@ -1,14 +1,15 @@
 package matal.bookmark.domain.repository;
 
-import java.util.List;
 import matal.bookmark.domain.Bookmark;
 import matal.member.domain.Member;
 import matal.store.domain.Store;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
-    List<Bookmark> findBookmarksByMemberId(Long id);
+    Page<Bookmark> findBookmarksByMemberId(Long id, Pageable pageable);
 
     Boolean existsBookmarkByStoreAndMember(Store store, Member member);
 }

--- a/src/main/java/matal/bookmark/service/BookmarkService.java
+++ b/src/main/java/matal/bookmark/service/BookmarkService.java
@@ -1,6 +1,5 @@
 package matal.bookmark.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import matal.bookmark.domain.Bookmark;
 import matal.bookmark.domain.repository.BookmarkRepository;
@@ -14,12 +13,17 @@ import matal.member.domain.repository.MemberRepository;
 import matal.member.dto.request.AuthMember;
 import matal.store.domain.Store;
 import matal.store.domain.repository.StoreRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class BookmarkService {
+
+    private static final int PAGE_SIZE = 10;
 
     private final BookmarkRepository bookmarkRepository;
     private final MemberRepository memberRepository;
@@ -40,10 +44,10 @@ public class BookmarkService {
     }
 
     @Transactional(readOnly = true)
-    public List<BookmarkResponseDto> getBookmarks(AuthMember authMember) {
+    public Page<BookmarkResponseDto> getBookmarks(AuthMember authMember, int page) {
         validateMember(authMember.memberId());
-        return bookmarkRepository.findBookmarksByMemberId(authMember.memberId())
-                .stream().map(BookmarkResponseDto::from).toList();
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+        return bookmarkRepository.findBookmarksByMemberId(authMember.memberId(), pageable).map(BookmarkResponseDto::from);
     }
 
     @Transactional

--- a/src/main/java/matal/store/controller/StoreController.java
+++ b/src/main/java/matal/store/controller/StoreController.java
@@ -31,7 +31,9 @@ public class StoreController {
                     content = {@Content(schema = @Schema(implementation = StoreListResponseDto.class))}),
             @ApiResponse(responseCode = "404", description = "실패",
                     content = {@Content(schema = @Schema(implementation = ErrorResponse.class))})})
-    public ResponseEntity<Page<StoreListResponseDto>> searchAndFilterStores(@RequestBody StoreSearchFilterRequestDto requestDto) {
+    public ResponseEntity<Page<StoreListResponseDto>> searchAndFilterStores(
+            @RequestBody StoreSearchFilterRequestDto requestDto)
+    {
         requestDto.validateFields();
         Page<StoreListResponseDto> response = storeService.searchAndFilterStores(requestDto);
         return ResponseEntity.ok().body(response);

--- a/src/main/java/matal/store/service/StoreService.java
+++ b/src/main/java/matal/store/service/StoreService.java
@@ -20,11 +20,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class StoreService {
 
+    private static final int PAGE_SIZE = 10;
+
     private final StoreRepository storeRepository;
 
     public Page<StoreListResponseDto> searchAndFilterStores(StoreSearchFilterRequestDto filterRequestDto) {
 
-        Pageable pageable = PageRequest.of(filterRequestDto.getPage(), 10);
+        Pageable pageable = PageRequest.of(filterRequestDto.getPage(), PAGE_SIZE);
 
         return storeRepository.searchAndFilterStores(
                 filterRequestDto.getSearchKeywords(),
@@ -54,14 +56,14 @@ public class StoreService {
     public Page<StoreListResponseDto> findAll(int page,
                                               String orderByRatio,
                                               String orderByPositiveRatio) {
-        Pageable pageable = PageRequest.of(page, 10);
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
         return storeRepository.findAllOrderByRatingOrPositiveRatio(orderByRatio,orderByPositiveRatio, pageable).map(StoreListResponseDto::from);
     }
 
     public Page<StoreListResponseDto> findTop() {
         Sort sortAll = Sort.by("rating").descending()
                 .and(Sort.by("positiveRatio").descending());
-        Pageable pageable = PageRequest.of(0, 10, sortAll);
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE, sortAll);
         return storeRepository.findAll(pageable).map(StoreListResponseDto::from);
     }
 }


### PR DESCRIPTION
## 개요

- 회원의 북마크 조회 시 리스트 형태로 모든 데이터를 반환하는 것을 `Page`를 적용하여 10개씩 반환하도록 수정 요구

### PR 타입

- 리팩터링

### 반영 브랜치

- refactor/58-bookmark-response-page -> main

## 변경 사항

- `List<>` -> `Page<>` 반환 형태 변경
- BookmarkController & Service 테스트 코드 변경
- `PageSize`를 상수화 변수로 변경

### 테스트 결과

- [X] 테스트 코드 정상 작동 확인
- [X] 빌드 정상 확인