### PR TITLE
Perf: AWS ElastiCache 도입 및 Redis, Lettuce 설정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - perf/61-elasticache-redis-lettuce
 
 jobs:
   build:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - perf/61-elasticache-redis-lettuce
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web-services'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
     implementation 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
 
     runtimeOnly 'com.mysql:mysql-connector-j'
-    runtimeOnly 'com.h2database:h2'
 
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/matal/MatalApplication.java
+++ b/src/main/java/matal/MatalApplication.java
@@ -3,8 +3,10 @@ package matal;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.cache.annotation.EnableCaching;
 
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@SpringBootApplication
+@EnableCaching
 public class MatalApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/matal/global/ServerController.java
+++ b/src/main/java/matal/global/ServerController.java
@@ -1,0 +1,17 @@
+package matal.global;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "Server Controller", description = "서버 작동 여부 확인")
+public class ServerController {
+
+    @GetMapping("/api/health")
+    @Operation(summary = "서버 동작 확인", description = "서버 동작을 확인하기 위해 사용하는 API")
+    public String healthCheck() {
+        return "hello, matal!";
+    }
+}

--- a/src/main/java/matal/global/config/RedisCacheConfig.java
+++ b/src/main/java/matal/global/config/RedisCacheConfig.java
@@ -1,0 +1,30 @@
+package matal.global.config;
+
+import java.time.Duration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisCacheConfig {
+
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofHours(1))
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(cacheConfig)
+                .build();
+    }
+}

--- a/src/main/java/matal/global/config/RedisCacheConfig.java
+++ b/src/main/java/matal/global/config/RedisCacheConfig.java
@@ -1,6 +1,7 @@
 package matal.global.config;
 
 import java.time.Duration;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -13,10 +14,13 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisCacheConfig {
 
+    @Value("${spring.data.redis.ttl-hours}")
+    private int ENTRY_TTL_HOURS;
+
     @Bean
     public RedisCacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
         RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofHours(1))
+                .entryTtl(Duration.ofHours(ENTRY_TTL_HOURS))
                 .disableCachingNullValues()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair
                         .fromSerializer(new StringRedisSerializer()))

--- a/src/main/java/matal/global/config/RedisConfig.java
+++ b/src/main/java/matal/global/config/RedisConfig.java
@@ -1,0 +1,23 @@
+package matal.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    private String REDIS_HOST;
+
+    private int REDIS_PORT;
+
+    @Bean
+    public RedisConnectionFactory RedisConfig () {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+        configuration.setHostName(REDIS_HOST);
+        configuration.setPort(REDIS_PORT);
+        return new LettuceConnectionFactory(configuration);
+    }
+}

--- a/src/main/java/matal/global/config/RedisConfig.java
+++ b/src/main/java/matal/global/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package matal.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -9,8 +10,10 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 @Configuration
 public class RedisConfig {
 
+    @Value("${spring.data.redis.host}")
     private String REDIS_HOST;
 
+    @Value("${spring.data.redis.port}")
     private int REDIS_PORT;
 
     @Bean

--- a/src/main/java/matal/store/controller/StoreController.java
+++ b/src/main/java/matal/store/controller/StoreController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import matal.global.exception.ErrorResponse;
+import matal.store.dto.RestPage;
 import matal.store.dto.request.StoreSearchFilterRequestDto;
 import matal.store.dto.response.StoreListResponseDto;
 import matal.store.dto.response.StoreResponseDto;
@@ -58,11 +59,11 @@ public class StoreController {
                     content = {@Content(schema = @Schema(implementation = StoreListResponseDto.class))}),
             @ApiResponse(responseCode = "404", description = "실패"),
     })
-    public ResponseEntity<Page<StoreListResponseDto>> getStoreAll(
+    public ResponseEntity<RestPage<StoreListResponseDto>> getStoreAll(
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "orderByRating", required = false) String orderByRating,
             @RequestParam(name = "orderByPositiveRatio", required = false) String orderByPositiveRatio) {
-        Page<StoreListResponseDto> storeListResponse = storeService.findAll(page, orderByRating, orderByPositiveRatio);
+        RestPage<StoreListResponseDto> storeListResponse = storeService.findAll(page, orderByRating, orderByPositiveRatio);
         return ResponseEntity.ok().body(storeListResponse);
     }
 
@@ -73,8 +74,8 @@ public class StoreController {
                     content = {@Content(schema = @Schema(implementation = StoreListResponseDto.class))}),
             @ApiResponse(responseCode = "404", description = "실패"),
     })
-    private ResponseEntity<Page<StoreListResponseDto>> getStoreTop() {
-        Page<StoreListResponseDto> storeListResponse = storeService.findTop();
+    private ResponseEntity<RestPage<StoreListResponseDto>> getStoreTop() {
+        RestPage<StoreListResponseDto> storeListResponse = storeService.findTop();
         return ResponseEntity.ok().body(storeListResponse);
     }
 }

--- a/src/main/java/matal/store/dto/RestPage.java
+++ b/src/main/java/matal/store/dto/RestPage.java
@@ -3,15 +3,17 @@ package matal.store.dto;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @JsonIgnoreProperties(ignoreUnknown = true, value = {"pageable"})
 public class RestPage<T> extends PageImpl<T> {
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-    public RestPage(@JsonProperty("content") java.util.List<T> content,
+    public RestPage(@JsonProperty("content") List<T> content,
                     @JsonProperty("number") int page,
                     @JsonProperty("size") int size,
                     @JsonProperty("totalElements") long totalElements) {
@@ -21,5 +23,9 @@ public class RestPage<T> extends PageImpl<T> {
 
     public RestPage(Page<T> page) {
         super(page.getContent(), page.getPageable(), page.getTotalElements());
+    }
+
+    public RestPage(List<T> content, Pageable pageable, Long total) {
+        super(content, pageable, total);
     }
 }

--- a/src/main/java/matal/store/dto/RestPage.java
+++ b/src/main/java/matal/store/dto/RestPage.java
@@ -1,0 +1,25 @@
+package matal.store.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"pageable"})
+public class RestPage<T> extends PageImpl<T> {
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public RestPage(@JsonProperty("content") java.util.List<T> content,
+                    @JsonProperty("number") int page,
+                    @JsonProperty("size") int size,
+                    @JsonProperty("totalElements") long totalElements) {
+
+        super(content, PageRequest.of(page, size), totalElements);
+    }
+
+    public RestPage(Page<T> page) {
+        super(page.getContent(), page.getPageable(), page.getTotalElements());
+    }
+}

--- a/src/main/java/matal/store/service/StoreService.java
+++ b/src/main/java/matal/store/service/StoreService.java
@@ -8,6 +8,7 @@ import matal.store.dto.response.StoreListResponseDto;
 import matal.store.dto.response.StoreResponseDto;
 import matal.store.domain.Store;
 import matal.store.domain.repository.StoreRepository;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -46,6 +47,7 @@ public class StoreService {
         ).map(StoreListResponseDto::from);
     }
 
+    @Cacheable(value = "store", key = "'store_' + #storeId")
     public StoreResponseDto findById(Long storeId) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new NotFoundException(ResponseCode.STORE_NOT_FOUND_ID));
@@ -53,6 +55,7 @@ public class StoreService {
         return StoreResponseDto.from(store);
     }
 
+    @Cacheable(value = "stores", key = "'stores_' + #page")
     public Page<StoreListResponseDto> findAll(int page,
                                               String orderByRatio,
                                               String orderByPositiveRatio) {
@@ -60,6 +63,7 @@ public class StoreService {
         return storeRepository.findAllOrderByRatingOrPositiveRatio(orderByRatio,orderByPositiveRatio, pageable).map(StoreListResponseDto::from);
     }
 
+    @Cacheable(value = "top10Stores", key = "'topStores_10'")
     public Page<StoreListResponseDto> findTop() {
         Sort sortAll = Sort.by("rating").descending()
                 .and(Sort.by("positiveRatio").descending());

--- a/src/main/java/matal/store/service/StoreService.java
+++ b/src/main/java/matal/store/service/StoreService.java
@@ -3,6 +3,7 @@ package matal.store.service;
 import lombok.RequiredArgsConstructor;
 import matal.global.exception.NotFoundException;
 import matal.global.exception.ResponseCode;
+import matal.store.dto.RestPage;
 import matal.store.dto.request.StoreSearchFilterRequestDto;
 import matal.store.dto.response.StoreListResponseDto;
 import matal.store.dto.response.StoreResponseDto;
@@ -55,19 +56,29 @@ public class StoreService {
         return StoreResponseDto.from(store);
     }
 
-    @Cacheable(value = "stores", key = "'stores_' + #page")
-    public Page<StoreListResponseDto> findAll(int page,
-                                              String orderByRatio,
-                                              String orderByPositiveRatio) {
+    @Cacheable(value = "stores", key = "'stores_' + #orderByRatio + '_' + #orderByPositiveRatio + '_' + #page")
+    public RestPage<StoreListResponseDto> findAll(int page,
+                                                  String orderByRatio,
+                                                  String orderByPositiveRatio) {
+
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
-        return storeRepository.findAllOrderByRatingOrPositiveRatio(orderByRatio,orderByPositiveRatio, pageable).map(StoreListResponseDto::from);
+        Page<StoreListResponseDto> responseDtoPage =
+                storeRepository.findAllOrderByRatingOrPositiveRatio(orderByRatio,orderByPositiveRatio, pageable)
+                        .map(StoreListResponseDto::from);
+
+        return new RestPage<>(responseDtoPage);
     }
 
     @Cacheable(value = "top10Stores", key = "'topStores_10'")
-    public Page<StoreListResponseDto> findTop() {
+    public RestPage<StoreListResponseDto> findTop() {
+
         Sort sortAll = Sort.by("rating").descending()
                 .and(Sort.by("positiveRatio").descending());
         Pageable pageable = PageRequest.of(0, PAGE_SIZE, sortAll);
-        return storeRepository.findAll(pageable).map(StoreListResponseDto::from);
+
+        Page<StoreListResponseDto> responseDtoPage =
+                storeRepository.findAll(pageable).map(StoreListResponseDto::from);
+
+        return new RestPage<>(responseDtoPage);
     }
 }

--- a/src/test/java/matal/store/controller/StoreControllerTest.java
+++ b/src/test/java/matal/store/controller/StoreControllerTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import matal.global.exception.NotFoundException;
 import matal.global.exception.ResponseCode;
+import matal.store.dto.RestPage;
 import matal.store.dto.request.StoreSearchFilterRequestDto;
 import matal.store.dto.response.StoreListResponseDto;
 import matal.store.dto.response.StoreResponseDto;
@@ -288,10 +289,10 @@ public class StoreControllerTest {
                 .sorted(Comparator.comparingDouble(StoreListResponseDto::positiveRatio).reversed())
                 .collect(Collectors.toList());
         Page<StoreListResponseDto> storePage = new PageImpl<>(sortedStores);
-
+        RestPage<StoreListResponseDto> responseDtoPage = new RestPage<>(storePage);
 
         // when
-        when(storeService.findAll(0, "DESC", "DESC")).thenReturn(storePage);
+        when(storeService.findAll(0, "DESC", "DESC")).thenReturn(responseDtoPage);
 
         // then
         mockMvc.perform(get("/api/stores/all")
@@ -347,9 +348,10 @@ public class StoreControllerTest {
                 stores.get(9));
 
         Page<StoreListResponseDto> storePage = new PageImpl<>(topStores);
+        RestPage<StoreListResponseDto> responseDtoPage = new RestPage<>(storePage);
 
         // when
-        when(storeService.findTop()).thenReturn(storePage);
+        when(storeService.findTop()).thenReturn(responseDtoPage);
 
         // then
         mockMvc.perform(get("/api/stores/top")


### PR DESCRIPTION
## 개요

- ElastiCache를 도입해 데이터를 캐싱하여 기존 API를 더 빠르게 조회하고자 함.

### PR 타입

- 기능 추가
- 환경 변수 설정

### 반영 브랜치

- perf/61-elasticache-redis-lettuce -> main

## 변경 사항

- spring-data-redis모듈 추가
- h2 데이터베이를 mysql로 변경하여 테스트에 용이하게 하고자 함.
- redis, lettuce 환경 변수 설정
- 빈번하게 조회가 이루어지는 `/api/stores/top`, `/api/stores/{id}`, `/api/stores/all`에 `Cacheable` 어노테이션으로 `key`, `value` 설정
- `Page<>` 의 기본생성자 부재에 따른 문제 발생으로 `RestPage<>` Wrapper 객체 구현 및 적용

### 테스트 결과

- [X] 로컬 환경에서 정상적으로 데이터가 캐싱되는 것을 확인
- [X] 배포 환경에서 정상적으로 redis 로 캐싱되는 것을 확인