### PR TITLE
feature: 북마크, 가게 아이디 조회 API 구현 & N+1 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,13 +56,13 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
-processResources.dependsOn('copySecret')
-
-tasks.register('copySecret', Copy) {
-    from './matal-submodule'
-    include "application*.yml"
-    into './src/main/resources'
-}
+//processResources.dependsOn('copySecret')
+//
+//tasks.register('copySecret', Copy) {
+//    from './matal-submodule'
+//    include "application*.yml"
+//    into './src/main/resources'
+//}
 
 tasks.named("jar") {
     enabled = false;

--- a/src/main/java/matal/bookmark/controller/BookmarkController.java
+++ b/src/main/java/matal/bookmark/controller/BookmarkController.java
@@ -78,10 +78,10 @@ public class BookmarkController {
                     content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
             @ApiResponse(responseCode = "404", description = "회원 조회 실패",
                     content = {@Content(schema = @Schema(implementation = ErrorResponse.class))})})
-    public ResponseEntity<List<BookmarkStoreIdsResponseDto>> getBookmarksId(
+    public ResponseEntity<List<BookmarkStoreIdsResponseDto>> getBookmarkStoreIds(
             @LoginMember @Parameter(hidden = true) AuthMember authMember)
     {
-        List<BookmarkStoreIdsResponseDto> bookmarkResponse = bookmarkService.getBookmarkAndStoreIds(authMember);
+        List<BookmarkStoreIdsResponseDto> bookmarkResponse = bookmarkService.getBookmarkStoreIds(authMember);
         return ResponseEntity.ok(bookmarkResponse);
     }
 

--- a/src/main/java/matal/bookmark/controller/BookmarkController.java
+++ b/src/main/java/matal/bookmark/controller/BookmarkController.java
@@ -7,8 +7,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import matal.bookmark.dto.response.BookmarkResponseDto;
+import matal.bookmark.dto.response.BookmarkStoreIdsResponseDto;
 import matal.bookmark.service.BookmarkService;
 import matal.global.auth.LoginMember;
 import matal.global.exception.ErrorResponse;
@@ -51,7 +53,7 @@ public class BookmarkController {
     }
 
     @GetMapping
-    @Operation(summary = "북마크 조회 기능", description = "사용자가 북마크한 가게들을 조회할 때 사용하는 API")
+    @Operation(summary = "북마크 페이징 조회 기능", description = "사용자가 북마크한 가게들을 10개씩 조회할 때 사용하는 API")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "북마크 조회 성공",
                     content = {@Content(schema = @Schema(implementation = Void.class))}),
@@ -64,6 +66,22 @@ public class BookmarkController {
             @RequestParam(name = "page", defaultValue = "0") int page)
     {
         Page<BookmarkResponseDto> bookmarkResponse = bookmarkService.getBookmarks(authMember, page);
+        return ResponseEntity.ok(bookmarkResponse);
+    }
+
+    @GetMapping("/ids")
+    @Operation(summary = "북마크 IDs 조회 기능", description = "사용자가 북마크한 가게들을 모두 조회할 때 사용하는 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "북마크 조회 성공",
+                    content = {@Content(schema = @Schema(implementation = Void.class))}),
+            @ApiResponse(responseCode = "401", description = "회원 세션 정보 없음",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "404", description = "회원 조회 실패",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))})})
+    public ResponseEntity<List<BookmarkStoreIdsResponseDto>> getBookmarksId(
+            @LoginMember @Parameter(hidden = true) AuthMember authMember)
+    {
+        List<BookmarkStoreIdsResponseDto> bookmarkResponse = bookmarkService.getBookmarkAndStoreIds(authMember);
         return ResponseEntity.ok(bookmarkResponse);
     }
 

--- a/src/main/java/matal/bookmark/domain/Bookmark.java
+++ b/src/main/java/matal/bookmark/domain/Bookmark.java
@@ -2,6 +2,7 @@ package matal.bookmark.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,11 +30,11 @@ public class Bookmark extends BaseTimeEntity {
     @Column(name = "bookmark_id")
     private Long bookmarkId;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "store_id")
     private Store store;
 

--- a/src/main/java/matal/bookmark/domain/repository/BookmarkRepository.java
+++ b/src/main/java/matal/bookmark/domain/repository/BookmarkRepository.java
@@ -1,15 +1,28 @@
 package matal.bookmark.domain.repository;
 
+import java.util.List;
 import matal.bookmark.domain.Bookmark;
+import matal.bookmark.dto.response.BookmarkStoreIdsResponseDto;
 import matal.member.domain.Member;
 import matal.store.domain.Store;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.EntityGraph.EntityGraphType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
-    Page<Bookmark> findBookmarksByMemberId(Long id, Pageable pageable);
+    @EntityGraph(attributePaths = {"store"}, type = EntityGraphType.FETCH)
+    @Query("SELECT DISTINCT b FROM Bookmark b LEFT JOIN b.store WHERE b.member.id = :memberId")
+    Page<Bookmark> findBookmarksByMemberId(@Param("memberId") Long id, Pageable pageable);
+
+    @Query("SELECT new matal.bookmark.dto.response.BookmarkStoreIdsResponseDto(b.bookmarkId, b.store.storeId) " +
+            "FROM Bookmark b WHERE b.member.id = :memberId")
+    List<BookmarkStoreIdsResponseDto> findBookmarkStoreIdsByMemberId(@Param("memberId") Long memberId);
+
 
     Boolean existsBookmarkByStoreAndMember(Store store, Member member);
 }

--- a/src/main/java/matal/bookmark/dto/response/BookmarkStoreIdsResponseDto.java
+++ b/src/main/java/matal/bookmark/dto/response/BookmarkStoreIdsResponseDto.java
@@ -1,14 +1,5 @@
 package matal.bookmark.dto.response;
 
-import matal.bookmark.domain.Bookmark;
-
 public record BookmarkStoreIdsResponseDto(Long bookmarkId,
                                           Long storeId) {
-
-    public static BookmarkStoreIdsResponseDto from(Bookmark bookmark) {
-        return new BookmarkStoreIdsResponseDto(
-                bookmark.getBookmarkId(),
-                bookmark.getStore().getStoreId()
-        );
-    }
 }

--- a/src/main/java/matal/bookmark/dto/response/BookmarkStoreIdsResponseDto.java
+++ b/src/main/java/matal/bookmark/dto/response/BookmarkStoreIdsResponseDto.java
@@ -1,0 +1,14 @@
+package matal.bookmark.dto.response;
+
+import matal.bookmark.domain.Bookmark;
+
+public record BookmarkStoreIdsResponseDto(Long bookmarkId,
+                                          Long storeId) {
+
+    public static BookmarkStoreIdsResponseDto from(Bookmark bookmark) {
+        return new BookmarkStoreIdsResponseDto(
+                bookmark.getBookmarkId(),
+                bookmark.getStore().getStoreId()
+        );
+    }
+}

--- a/src/main/java/matal/bookmark/service/BookmarkService.java
+++ b/src/main/java/matal/bookmark/service/BookmarkService.java
@@ -1,8 +1,10 @@
 package matal.bookmark.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import matal.bookmark.domain.Bookmark;
 import matal.bookmark.domain.repository.BookmarkRepository;
+import matal.bookmark.dto.response.BookmarkStoreIdsResponseDto;
 import matal.bookmark.dto.response.BookmarkResponseDto;
 import matal.global.exception.AlreadyExistException;
 import matal.global.exception.AuthException;
@@ -48,6 +50,12 @@ public class BookmarkService {
         validateMember(authMember.memberId());
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
         return bookmarkRepository.findBookmarksByMemberId(authMember.memberId(), pageable).map(BookmarkResponseDto::from);
+    }
+
+    @Transactional(readOnly = true)
+    public List<BookmarkStoreIdsResponseDto> getBookmarkAndStoreIds(AuthMember authMember) {
+        validateMember(authMember.memberId());
+        return bookmarkRepository.findBookmarkStoreIdsByMemberId(authMember.memberId());
     }
 
     @Transactional

--- a/src/main/java/matal/bookmark/service/BookmarkService.java
+++ b/src/main/java/matal/bookmark/service/BookmarkService.java
@@ -53,7 +53,7 @@ public class BookmarkService {
     }
 
     @Transactional(readOnly = true)
-    public List<BookmarkStoreIdsResponseDto> getBookmarkAndStoreIds(AuthMember authMember) {
+    public List<BookmarkStoreIdsResponseDto> getBookmarkStoreIds(AuthMember authMember) {
         validateMember(authMember.memberId());
         return bookmarkRepository.findBookmarkStoreIdsByMemberId(authMember.memberId());
     }

--- a/src/test/java/matal/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/matal/bookmark/service/BookmarkServiceTest.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import matal.bookmark.domain.Bookmark;
 import matal.bookmark.domain.repository.BookmarkRepository;
 import matal.bookmark.dto.response.BookmarkResponseDto;
+import matal.bookmark.dto.response.BookmarkStoreIdsResponseDto;
 import matal.global.exception.NotFoundException;
 import matal.global.exception.ResponseCode;
 import matal.member.domain.Member;
@@ -154,7 +155,7 @@ public class BookmarkServiceTest {
     }
 
     @Test
-    @DisplayName("북마크 리스트 조회 성공 테스트")
+    @DisplayName("북마크 페이지 조회 성공 테스트")
     void testGetBookmarksSuccess() {
         // given
         List<Bookmark> bookmarks = List.of(
@@ -184,7 +185,7 @@ public class BookmarkServiceTest {
     }
 
     @Test
-    @DisplayName("북마크 리스트 조회 시 회원 정보 없음으로 인한 실패 테스트")
+    @DisplayName("북마크 페이지 조회 시 회원 정보 없음으로 인한 실패 테스트")
     void testGetBookmarksFailure() {
         // given
 
@@ -194,6 +195,48 @@ public class BookmarkServiceTest {
 
         // then
         assertThrows(NotFoundException.class, () -> bookmarkService.getBookmarks(mockMember, 0));
+    }
+
+    @Test
+    @DisplayName("북마크 가게 아이디 조회 성공 테스트")
+    void testGetBookmarkStoresIdsSuccess() {
+        // given
+        List<BookmarkStoreIdsResponseDto> bookmarks = List.of(
+                new BookmarkStoreIdsResponseDto(
+                        1L,
+                        1L
+                ),
+                new BookmarkStoreIdsResponseDto(
+                        1L,
+                        2L
+                )
+        );
+
+
+        // when
+        when(memberRepository.findById(any())).thenReturn(Optional.of(member));
+        when(bookmarkRepository.findBookmarkStoreIdsByMemberId(any())).thenReturn(bookmarks);
+
+        // then
+        List<BookmarkStoreIdsResponseDto> response = bookmarkService.getBookmarkStoreIds(mockMember);
+        assertThat(response.get(0).bookmarkId()).isEqualTo(bookmarks.get(0).bookmarkId());
+        assertThat(response.get(1).bookmarkId()).isEqualTo(bookmarks.get(1).bookmarkId());
+        assertThat(response.get(0).storeId()).isEqualTo(bookmarks.get(0).storeId());
+        assertThat(response.get(1).storeId()).isEqualTo(bookmarks.get(1).storeId());
+
+    }
+
+    @Test
+    @DisplayName("북마크 가게 아이디 조회 시 회원 정보 없음으로 인한 실패 테스트")
+    void testGetBookmarkStoresIdsFailure() {
+        // given
+
+        // when
+        when(memberRepository.findById(any()))
+                .thenThrow(new NotFoundException(ResponseCode.MEMBER_NOT_FOUND_ID));
+
+        // then
+        assertThrows(NotFoundException.class, () -> bookmarkService.getBookmarkStoreIds(mockMember));
     }
 
     @Test


### PR DESCRIPTION
## 개요

- 클라이언트의 북마크 표시를 위한 북마크, 가게 아이디 조회 API 구현 및 N+1 문제를 해결하기 위한 FetchType.Lazy 설정과 쿼리 최적화

### PR 타입

- 기능 추가
- 성능 최적화

### 반영 브랜치

- feature/63-bookmark-all-n+1-solve -> main

## 변경 사항

- bookmark, store Id를 반환하는 API 구현
- 구현한 API에 대한 테스트 코드 작성
- bookmark와 store ID만을 조회하기 위한 JPQL 구현
- N+1 문제 해결을 위한 FetchType.LAZY와 EntityGraph 설정하여 store 엔티티를 함께 로딩하도록 설정
- 구현한 API의 테스트 코드 작성

### 테스트 결과

- [X] Swagger를 통해 N+1 문제 해결 확인 
- [X] 빌드 테스트 정상 작동 확인