### PR TITLE
fix: LOG_PATH 로그 폴더 생성 경로 문제

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -7,7 +7,7 @@
     <property name="ERROR_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [ERROR] [%logger{40}] [%F:%line] [%M] : %msg%n"/>
     <property name="INFO_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] [INFO] %msg%n"/>
 
-    <property name="LOG_PATH" value="../logs"/>
+    <property name="LOG_PATH" value="/home/ubuntu/backend/logs"/>
     <property name="MAX_FILE_SIZE" value="50MB"/>
     <property name="MAX_HISTORY" value="30"/>
     <property name="TOTAL_SIZE_CAP" value="1GB"/>


### PR DESCRIPTION
## 개요

- 배포 스크립트의 로그 폴더 생성 경로와 로그백 설정 파일의 로그 폴더 저장 경로 불일치

### PR 타입

- 버그 수정

### 변경 사항

- logback-spring.xml의 LOG_PATH 경로 수정 -> deploy.sh 의 LOG_BASE_DIR 경로와 통일

### 테스트 결과

- X